### PR TITLE
Set ActiveStatus by default after version checking

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,8 @@ class Operator(CharmBase):
         except NoCompatibleVersions as err:
             self.model.unit.status = BlockedStatus(str(err))
             return
+        else:
+            self.model.unit.status = ActiveStatus()
 
         self.framework.observe(self.on.install, self.set_pod_spec)
         self.framework.observe(self.on.upgrade_charm, self.set_pod_spec)


### PR DESCRIPTION
Prevents a charm from getting stuck in WaitingStatus