### PR TITLE
Add extra service name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -133,6 +133,28 @@ class Operator(CharmBase):
                     }
                 ],
             },
+            k8s_resources={
+                "kubernetesResources": {
+                    "services": [
+                        {
+                            "name": "metadata-grpc-service",
+                            "spec": {
+                                "selector": {
+                                    "app.kubernetes.io/name": self.model.app.name
+                                },
+                                "ports": [
+                                    {
+                                        "name": "grpc-api",
+                                        "port": int(config["port"]),
+                                        "protocol": "TCP",
+                                        "targetPort": int(config["port"]),
+                                    },
+                                ],
+                            },
+                        }
+                    ]
+                }
+            },
         )
         self.model.unit.status = ActiveStatus()
 


### PR DESCRIPTION
Some upstream code defaults to looking for `metadata-grpc-service` as the MLMD service name. That can be overridden with environment variables, but it would be nice to have that set up automatically.

Fixes #3 