### PR TITLE
Build Charm through tox with local Schemas

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -48,8 +48,8 @@ jobs:
     - name: Install dependencies
       run: |
         set -eux
-        sudo apt install python3-pip
-        sudo pip3 install charmcraft
+        sudo apt install python3-pip tox
+        sudo snap install charmcraft
         sudo snap install juju --classic
         sudo snap install juju-wait --classic
         sudo snap install yq
@@ -63,7 +63,7 @@ jobs:
     - name: Deploy charm
       run: |
         set -eux
-        charmcraft build
+        tox -e build
 
         juju deploy ./*.charm \
           --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       run: |
         set -eux
         sudo snap install charm --classic
-        sudo pip3 install charmcraft
+        sudo snap install charmcraft
         sudo snap install yq
 
     - name: Publish charm
@@ -31,7 +31,7 @@ jobs:
         CS_URL="cs:~kubeflow-charmers/mlmd"
 
         IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
-        charmcraft build
+        tox -e build
         docker pull $IMAGE
         charm push ./*.charm $CS_URL --resource oci-image=$IMAGE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.1.0
 oci-image==1.0.0
-serialized-data-interface==0.2.0
+serialized-data-interface==0.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ setenv =
 deps =
     -rtest-requirements.txt
     -rrequirements.txt
+allowlist_externals =
+    charmcraft
 
 [testenv:unit]
 commands =
@@ -20,3 +22,7 @@ commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests
 
+[testenv:build]
+commands =
+    charmcraft build
+    python3 -m serialized_data_interface.local_sdi


### PR DESCRIPTION
Adds build step in tox.ini for building the charm and injecting local SDI schemas into the build zip.

Modify GH Actions and integration tests  with new build step