### PR TITLE
fix: force CheckFailed msg arg to string

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -181,12 +181,12 @@ class Operator(CharmBase):
 class CheckFailed(Exception):
     """ Raise this exception if one of the checks in main fails. """
 
-    def __init__(self, msg, status_type=None):
+    def __init__(self, msg: str, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes error where non-string input will cause an exception when instantiating the `status`