### PR TITLE
unpin `black` to avoid a dependency issue

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -3,4 +3,4 @@
 
 flake8
 flake8-copyright<0.3
-black==20.8b1
+black

--- a/src/charm.py
+++ b/src/charm.py
@@ -179,7 +179,7 @@ class Operator(CharmBase):
 
 
 class CheckFailed(Exception):
-    """ Raise this exception if one of the checks in main fails. """
+    """Raise this exception if one of the checks in main fails."""
 
     def __init__(self, msg: str, status_type=None):
         super().__init__()


### PR DESCRIPTION
The originally pinned version hits this error:
```
Traceback (most recent call last):
  File "/home/runner/work/mlmd-operator/mlmd-operator/.tox/lint/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/work/mlmd-operator/mlmd-operator/.tox/lint/lib/python3.8/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/home/runner/work/mlmd-operator/mlmd-operator/.tox/lint/lib/python3.8/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/work/mlmd-operator/mlmd-operator/.tox/lint/lib/python3.8/site-packages/click/__init__.py)
```
which should be fixed in the most recent version.  