### PR TITLE
fix: unpin pytest-operator to fix async test failures

### DIFF
--- a/test-integration-requirements.txt
+++ b/test-integration-requirements.txt
@@ -1,4 +1,4 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-pytest-operator < 0.9
+pytest-operator


### PR DESCRIPTION
Older versions of `pytest-operator` incorrectly decorate the async `ops_test` fixture as `@pytest.fixture()` rather than `@pytest_asyncio.fixture()`.  This omission is hidden when `pytest-asyncio`'s `asyncio-mode=auto`, but using `=strict` results in a failure.

This fix unpins `pytest-operator` to get the latest version which includes the correct decorator.
