### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,8 +14,20 @@ resources:
 provides:
   grpc:
     interface: grpc
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: string
+          required:
+          - service
+          - port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
 requires:
   mysql:
     interface: mysql


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).