### PR TITLE
Pin CI dependencies to agreed versions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,17 +56,13 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Setup operator environment
-      uses: claudiubelu/actions-operator@18ebf92ae3043bd3dd15238e5d9b662d7ba08daf
+      uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
         channel: 1.24/stable
         # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
         bootstrap-options: "--agent-version=2.9.34"
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-
-    # TODO: Remove once the actions-operator does this automatically
-    - name: Configure kubectl
-      run: sg microk8s -c "microk8s config > ~/.kube/config"
 
     - name: Test
       run: sg microk8s -c "tox -vve integration -- --model testing"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -59,7 +59,7 @@ jobs:
       uses: claudiubelu/actions-operator@18ebf92ae3043bd3dd15238e5d9b662d7ba08daf
       with:
         provider: microk8s
-        channel: 1.22/stable
+        channel: 1.24/stable
         # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
         bootstrap-options: "--agent-version=2.9.34"
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju
+juju<3.1
 pytest-operator
 requests
 -r requirements.txt


### PR DESCRIPTION
- pin microk8s to 1.24/stable
- use charmed-kubernetes/actions-operator to Setup operator environment
- pin juju to <3.1 in requirements.in to avoid unsupported version error with agent 2.9.34