### PR TITLE
fix: Update `service` value sent through grpc relation data 

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -140,7 +140,7 @@ class Operator(CharmBase):
         if interfaces["grpc"]:
             interfaces["grpc"].send_data(
                 {
-                    "service": self.model.app.name,
+                    "service": "metadata-grpc-service",
                     "port": self.model.config["port"],
                 }
             )


### PR DESCRIPTION
Update `service` value sent through relation grpc to match the service created (`metadata-grpc-service`).