### PR TITLE
chore: bump image to 1.14.0 for CKF 1.8

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: gcr.io/tfx-oss-public/ml_metadata_store_server:1.0.0
+    upstream-source: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
 provides:
   grpc:
     interface: grpc


### PR DESCRIPTION
Bump image 1.0.0 -> 1.14.0 for CKF 1.8. 