### PR TITLE
refactor: revert relation name k8s-service-info -> grpc

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,7 +19,7 @@ resources:
     auto-fetch: true
     upstream-source: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
 provides:
-  k8s-service-info:
+  grpc:
     interface: k8s-service
 requires:
   mysql:

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,7 @@ logger = logging.getLogger()
 
 GRPC_SVC_NAME = "metadata-grpc-service"
 K8S_RESOURCE_FILES = ["src/templates/ml-pipeline-service.yaml.j2"]
-RELATION_NAME = "k8s-service-info"
+RELATION_NAME = "grpc"
 SQLITE_CONFIG_PROTO_DESTINATION = "/config/config.proto"
 SQLITE_CONFIG_PROTO = 'connection_config: {sqlite: {filename_uri: "file:/data/mlmd.db"}}'
 


### PR DESCRIPTION
Revert back the name of the relation to keep compatibility with requirer charms. This change also avoids breaking existing CIs and the CKF bundle, as the relation name defined there is just grpc.