### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in main

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -52,7 +52,7 @@ jobs:
       with:
         provider: microk8s
         channel: 1.25-strict/stable
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Test


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944