### PR TITLE
Feat: Add Terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -41,6 +41,14 @@ jobs:
       - name: Run unit tests
         run: tox -vve unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
+        
   integration:
     name: Integration Tests
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build/
 __pycache__/
 .tox
+venv/
+.terraform*
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,11 +2,11 @@
 
 This is a Terraform module facilitating the deployment of the mlmd charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
-
 ## Compatibility
 This terraform module is compatible with charms of version >= ckf-1.9 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
 ## API
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,7 @@ The module offers the following configurable inputs:
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(number) | Map of charm resources revisions | False |
+| `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
 
 ### Outputs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,7 +21,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on | True |
 | `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
-| `storage_directives`| map(string) | Map of the charm storage configuration | False |
+| `storage_directives`| map(string) | Map of the charm storage directives | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for mlmd
+
+This is a Terraform module facilitating the deployment of the mlmd charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(number) | Map of charm resources revisions | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "mlmd" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "mlmd" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,6 +21,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on | True |
 | `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
+| `storage_directives`| map(string) | Map of the charm storage configuration | False |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,6 +5,9 @@ This is a Terraform module facilitating the deployment of the mlmd charm, using 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
+## Compatibility
+This terraform module is compatible with charms of version >= ckf-1.9 due to changes in the charm's relations.
+
 ## API
 
 ### Inputs

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "mlmd" {
+  charm {
+    name     = "mlmd"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,9 +8,7 @@ resource "juju_application" "mlmd" {
   model     = var.model_name
   name      = var.app_name
   resources = var.resources
-  storage_directives = {
-    mlmd-data = "10G"
-  }
+  storage_directives = var.storage_directives
   trust = true
   units = 1
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,6 +8,9 @@ resource "juju_application" "mlmd" {
   model     = var.model_name
   name      = var.app_name
   resources = var.resources
+  storage_directives = {
+    mlmd-data = "10G"
+  }
   trust     = true
   units     = 1
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,11 +4,11 @@ resource "juju_application" "mlmd" {
     channel  = var.channel
     revision = var.revision
   }
-  config    = var.config
-  model     = var.model_name
-  name      = var.app_name
-  resources = var.resources
+  config             = var.config
+  model              = var.model_name
+  name               = var.app_name
+  resources          = var.resources
   storage_directives = var.storage_directives
-  trust = true
-  units = 1
+  trust              = true
+  units              = 1
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,6 @@ resource "juju_application" "mlmd" {
   storage_directives = {
     mlmd-data = "10G"
   }
-  trust     = true
-  units     = 1
+  trust = true
+  units = 1
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,12 +4,12 @@ output "app_name" {
 
 output "provides" {
   value = {
-    grpc  = "grpc",
+    grpc = "grpc",
   }
 }
 
 output "requires" {
   value = {
-    logging        = "logging"
+    logging = "logging"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "app_name" {
+  value = juju_application.mlmd.name
+}
+
+output "provides" {
+  value = {
+    grpc  = "grpc",
+  }
+}
+
+output "requires" {
+  value = {
+    logging        = "logging"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "model_name" {
 }
 
 variable "resources" {
-  description = "Map of resources revisions"
+  description = "Map of resources"
   type        = map(string)
   default     = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,6 +35,6 @@ variable "revision" {
 
 variable "storage_directives" {
   description = "Charm storage"
-  type = map(string)
-  default = null
+  type        = map(string)
+  default     = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,10 +21,9 @@ variable "model_name" {
   type        = string
 }
 
-# TODO: Update to a map of strings, once juju provider 0.14 is released
 variable "resources" {
   description = "Map of resources revisions"
-  type        = map(number)
+  type        = map(string)
   default     = null
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "mlmd"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+# TODO: Update to a map of strings, once juju provider 0.14 is released
+variable "resources" {
+  description = "Map of resources revisions"
+  type        = map(number)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,7 +34,7 @@ variable "revision" {
 }
 
 variable "storage_directives" {
-  description = "Charm storage"
+ description = "Map of storage directives"
   type        = map(string)
   default     = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,7 +36,5 @@ variable "revision" {
 variable "storage_directives" {
   description = "Charm storage"
   type = map(string)
-  default = {
-	mlmd-data = "10G"
-  }
+  default = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,3 +32,11 @@ variable "revision" {
   type        = number
   default     = null
 }
+
+variable "storage_directives" {
+  description = "Charm storage"
+  type = map(string)
+  default = {
+	mlmd-data = "10G"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,7 +34,7 @@ variable "revision" {
 }
 
 variable "storage_directives" {
- description = "Map of storage directives"
+  description = "Map of storage directives"
   type        = map(string)
   default     = null
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.13.0"
+      version = "~> 0.14.0"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.13.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Closes #98 

This PR creates a `terraform/` directory that hosts the Terraform module for this charm. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit).

I based the code on [this PR](https://github.com/canonical/argo-operators/pull/198).

To test the module:
- Clone the repository and switch to branch `kf-6237-terraform-module`.
- First run `tox -e tflint` to ensure that linting is correct
- Run `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.