### PR TITLE
ci: bump juju to 3.6 + charmcraft to 3.x/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,6 +60,7 @@ jobs:
         channel: 1.25-strict/stable
         juju-channel: 3.6/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
+        charmcraft-channel: 3.x/stable
 
     - name: Test
       run: sg snap_microk8s -c "tox -vve integration -- --model testing"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,7 +58,7 @@ jobs:
       with:
         provider: microk8s
         channel: 1.25-strict/stable
-        juju-channel: 3.4/stable
+        juju-channel: 3.6/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.x/stable


### PR DESCRIPTION
* Bump juju to 3.6/stable
* For uniformity, use charmcraft from 3.x/stable

Ref canonical/bundle-kubeflow#1176