### PR TITLE
feat: run the ml-metadata service as _daemon_ user

### DIFF
--- a/src/components/pebble_components.py
+++ b/src/components/pebble_components.py
@@ -32,6 +32,7 @@ class MlmdPebbleService(PebbleServiceComponent):
                         "summary": "entry point for MLMD GRPC Service",
                         "command": command,  # Must be a string
                         "startup": "enabled",
+                        "user": "_daemon_",
                     }
                 },
             }


### PR DESCRIPTION
This commit adds the user field in the ml-metadata service Pebble layer so that it and the Pebble client run as the _daemon_ user, which translates to the workload container only executing processes as a non-root user. Note this user is created in the ml-metadata rock. 

Dear reviewer:

This change has to be backported as well.