### PR TITLE
fix: add chown_component to ensure mounted storage belongs to _daemon_

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -4,5 +4,6 @@ jinja2
 juju<4.0
 pytest-operator
 requests
+sh
 tenacity
 charmed-kubeflow-chisme

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -12,6 +12,8 @@ aiosignal==1.3.1
     # via aiohttp
 anyio==4.5.2
     # via httpx
+appnope==0.1.4
+    # via ipython
 asttokens==3.0.0
     # via stack-data
 async-timeout==5.0.1
@@ -214,6 +216,8 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
+sh==2.2.2
+    # via -r requirements-integration.in
 six==1.17.0
     # via
     #   kubernetes

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,7 +75,13 @@ class Operator(CharmBase):
         # NOTE: if an oci-image other than the mlmd rock is to be used,
         # please make sure the user that runs the process and owns /data is updated
         self.chown_component = self.charm_reconciler.add(
-            component=ChownMountedStorageComponent(charm=self, name="chown-storage"),
+            component=ChownMountedStorageComponent(
+                charm=self,
+                name="chown-storage",
+                storage_path="/data",
+                workload_user="_daemon_",
+                workload_container="mlmd-grpc-server",
+            ),
             depends_on=[self.leadership_gate],
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ from lightkube.resources.core_v1 import Service
 from ops.charm import CharmBase
 from ops.main import main
 
+from components.chown_component import ChownMountedStorageComponent
 from components.pebble_components import MlmdPebbleService
 
 logger = logging.getLogger()
@@ -68,6 +69,16 @@ class Operator(CharmBase):
             depends_on=[self.leadership_gate],
         )
 
+        # The chown_component ensures the /data directory belongs to
+        # the _daemon_ user and group set in the mlmd rock
+        # This is added because of https://github.com/juju/juju/issues/19020
+        # NOTE: if an oci-image other than the mlmd rock is to be used,
+        # please make sure the user that runs the process and owns /data is updated
+        self.chown_component = self.charm_reconciler.add(
+            component=ChownMountedStorageComponent(charm=self, name="chown-storage"),
+            depends_on=[self.leadership_gate],
+        )
+
         self.mlmd_container = self.charm_reconciler.add(
             component=MlmdPebbleService(
                 charm=self,
@@ -83,7 +94,7 @@ class Operator(CharmBase):
                     )
                 ],
             ),
-            depends_on=[self.leadership_gate],
+            depends_on=[self.leadership_gate, self.chown_component],
         )
 
         self.charm_reconciler.install_default_event_handlers()

--- a/src/components/chown_component.py
+++ b/src/components/chown_component.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Ubuntu
+# Copyright 2025 Canonical
 # See LICENSE file for licensing details.
 
 import logging

--- a/src/components/chown_component.py
+++ b/src/components/chown_component.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright 2025 Ubuntu
+# See LICENSE file for licensing details.
+
+import logging
+from typing import Optional
+
+from charmed_kubeflow_chisme.components.component import Component
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from ops import ActiveStatus, CharmBase, StatusBase, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+
+class ChownMountedStorageComponent(Component):
+    """A component that ensures mounted storage is owned by the user that runs the service.
+
+    Args:
+        charm(CharmBase): this charm
+        name(str): name of the component
+        storage_path(str): the path where the storage is mounted and is desired to change owners.
+        workload_user(str): the user that runs the service (workload).
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        name: str,
+        storage_path: Optional[str] = "/data",
+        workload_user: Optional[str] = "_daemon_",
+    ):
+        super().__init__(charm, name)
+
+        self.storage_path = storage_path
+        self.workload_user = workload_user
+        self.charm = charm
+
+    def chown_storage_path(self, storage_path, workload_user) -> None:
+        container = self.charm.unit.get_container("mlmd-grpc-server")
+        if not container.can_connect():
+            raise ErrorWithStatus("Cannot connect to container mlmd-grpc-server", WaitingStatus)
+        container.exec(["chown", f"{workload_user}:{workload_user}", f"{storage_path}"]).wait()
+
+    def get_status(self) -> StatusBase:
+        try:
+            self.chown_storage_path(self.storage_path, self.workload_user)
+        except ErrorWithStatus as e:
+            return WaitingStatus(
+                "Cannot chown the storage path, waiting for container to be ready", e.status
+            )
+        return ActiveStatus()

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -101,6 +101,7 @@ def test_pebble_service_container_running(harness, mocked_lightkube_client):
     harness.set_can_connect(CONTAINER_NAME, True)
 
     harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())
+    harness.charm.chown_component.get_status = MagicMock(return_value=ActiveStatus())
 
     harness.charm.on.install.emit()
 
@@ -117,6 +118,7 @@ def test_install_before_pebble_service_container(harness, mocked_lightkube_clien
     harness.begin()
 
     harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())
+    harness.charm.chown_component.get_status = MagicMock(return_value=ActiveStatus())
 
     harness.charm.on.install.emit()
 


### PR DESCRIPTION
Due to juju/juju#19020, this charm must be responsible for setting the permissions to the mounted storage requested by the charm. This charm's workload needs rwx permissions on /data (the path where the storage is mounted) for it to work properly, and because 16638db changed the pebble service to be ran as non-root, the permissions are no longer guaranteed; therefore, this commit adds a chwon_component to the components graph that directly changes the ownership of the /data directory to the user defined in the Pebble layer.

Fixes #117

### Testing

1. Create a k8s node/cluster - I recommend Canonical k8s, this issue cannot be reproduced in microk8s with the hostpath-storage addon enabled. See #117 for details on why.
2. Deploy the charm in this PR from the `latest/edge/pr-119` Charmhub branch
3. Charm should be Active, as opposed to Waiting as reported in #117 
4. To confirm the changes are working, you can:

```
# Check the owner of the /data mount point
juju ssh --container mlmd-grpc-server mlmd/leader ls -l 

drwxr-xr-x   3 _daemon_ _daemon_ 4096 Feb 26 01:05 data

# Verify the workload logs
$ kubectl logs -nmlmd mlmd-0 -c mlmd-grpc-server

2025-02-26T01:25:12.937Z [pebble] HTTP API server listening on ":38813".
2025-02-26T01:25:12.937Z [pebble] Started daemon.
...
2025-02-26T01:25:34.066Z [pebble] Service "mlmd" starting: bin/metadata_store_server --metadata_store_server_config_file=/config/config.proto --grpc_port=8080 --enable_database_upgrade=true
2025-02-26T01:25:34.073Z [mlmd] WARNING: Logging before InitGoogleLogging() is written to STDERR
2025-02-26T01:25:34.073Z [mlmd] I0226 01:25:34.073716    20 metadata_store_server_main.cc:577] Server listening on 0.0.0.0:8080

# Confirm the workload process is running
juju ssh --container mlmd-grpc-server mlmd/leader ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0 1234484 13652 ?       Ssl  01:25   0:02 /charm/bin/pebble run
_daemon_      20  0.0  0.1 323944 17024 ?        Sl   01:25   0:00 bin/metadata_store_ser
```

### Upgrading

You can run a `juju refresh` from `ckf-1.9/stable` to `latest/edge/pr-119` and confirm the upgrade path is possible, but please NOTE that the mlmd image in the previous version is [this](https://github.com/canonical/mlmd-operator/blob/track/ckf-1.9/metadata.yaml#L20), which is the upstream one instead of the rock, therefore, not having the `_daemon_` user.

To correctly upgrade the charm you can:

#### If you build the charm from this PR

```
juju deploy mlmd --channel ckf-1.9/stable --trust

juju refresh mlmd --path=./mlmd_ubuntu-20.04-amd64.charm --resource oci-image=charmedkubeflow/ml-metadata:1.14.0-2a80c7b
```

#### If you did not build the charm from this PR

```
juju deploy mlmd --channel ckf-1.9/stable --trust
juju refresh mlmd --channel latest/edge/pr-119
```