### PR TITLE
feat: add automated backport support

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,2 @@
+automatic_backport_tracks:
+  -   track/ckf-1.10

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,6 +1,7 @@
 name: On Pull Request
 
 # On pull_request, we:
+# * create backport labels if it is against main, only when the PR is opened/reopened
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
 

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -9,6 +9,15 @@ on:
 
 jobs:
 
+  populate-labels:
+    name: Populate labels
+    if: github.base_ref == 'main' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
+    secrets: inherit
+    with:
+      track_file_path: ".github/automatic_backport_tracks.yaml"
+      label_prefix: "backport "
+
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml

--- a/.github/workflows/on_pull_request_closed.yaml
+++ b/.github/workflows/on_pull_request_closed.yaml
@@ -1,16 +1,21 @@
 name: On Pull Request Closed
 
+# When a pull request is pushed on the main branch, automatically
+# create backport PRs according to the labels on the pull request.
+# If there are conflicts, create a PR but leave it as draft.
+
 on:
   pull_request_target:
     types: [closed]
     branches:
-      - main
+    - main
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
+
   backport:
     name: Backport pull request
     if: github.event.pull_request.merged

--- a/.github/workflows/on_pull_request_closed.yaml
+++ b/.github/workflows/on_pull_request_closed.yaml
@@ -1,0 +1,18 @@
+name: On Pull Request Closed
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport pull request
+    if: github.event.pull_request.merged
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/backport-pr.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Base issue: https://github.com/canonical/bundle-kubeflow/issues/1421

This PR enables automatic creation of backports based on labels. Labels are automatically assigned on each new PR based on the value of the `.github/automatic_backport_tracks`.
