### PR TITLE
feat: Update manifests to match upstream kfp `2.16.0` release

### DIFF
--- a/src/components/pebble_components.py
+++ b/src/components/pebble_components.py
@@ -23,7 +23,9 @@ class MlmdPebbleService(PebbleServiceComponent):
             f" --metadata_store_server_config_file={self._metadata_store_server_config_file}"
             f" --grpc_port={self._grpc_port}"
             " --enable_database_upgrade=true"
-            " --grpc_channel_arguments=grpc.max_metadata_size=16384,grpc.max_receive_message_length=104857600,grpc.max_send_message_length=104857600"
+            " --grpc_channel_arguments=grpc.max_metadata_size=16384,"
+            "grpc.max_receive_message_length=104857600,"
+            "grpc.max_send_message_length=104857600"
         )
         layer = Layer(
             {

--- a/src/components/pebble_components.py
+++ b/src/components/pebble_components.py
@@ -23,6 +23,7 @@ class MlmdPebbleService(PebbleServiceComponent):
             f" --metadata_store_server_config_file={self._metadata_store_server_config_file}"
             f" --grpc_port={self._grpc_port}"
             " --enable_database_upgrade=true"
+            " --grpc_channel_arguments=grpc.max_metadata_size=16384,grpc.max_receive_message_length=104857600,grpc.max_send_message_length=104857600"
         )
         layer = Layer(
             {


### PR DESCRIPTION
Ref: https://github.com/canonical/kfp-operators/issues/869

This PR updates the charms according to the update to the manifests files corresponding to the `2.16.0` release of Kubeflow pipelines. This task is part of the team's upgrade to Kubeflow `26.03`.

The diff between the 2 version was generated by following the instructions on the [upstream README](https://github.com/kubeflow/manifests?tab=readme-ov-file#pipeline-definitions-stored-as-kubernetes-resources). It can be found [here](https://www.diffchecker.com/NW7YlN8J/).